### PR TITLE
Prevent MemcachedStore from crashing if no getMulti method

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -42,8 +42,12 @@ class MemcachedStore extends TaggableStore implements Store
         $this->setPrefix($prefix);
         $this->memcached = $memcached;
 
-        $this->onVersionThree = (new ReflectionMethod('Memcached', 'getMulti'))
-                            ->getNumberOfParameters() == 2;
+        try {
+            $this->onVersionThree = (new ReflectionMethod('Memcached', 'getMulti'))
+                                ->getNumberOfParameters() == 2;
+        } catch(\Exception $e) {
+            $this->onVersionThree = false; // Pre-Laravel 5.3 behaviour
+        }
     }
 
     /**


### PR DESCRIPTION
Some versions of PHP memcached, in particular the PEAR version included
in the Laragon Windows development environment don’t support the
getMulti method. Prior to 5.3 that wasn’t a problem as long as your
code never called the “many” function, but in 5.3 the constructor
crashes the app.

Protect the attempt to get the parameters of getMulti so that if the
getMulti method doesn’t exist, we simply default to the 5.2, and
earlier, behaviour of the class.